### PR TITLE
 Anthropic   API 兼容的第三方服务

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,124 @@
+# GEMINI.md - Course Materials RAG System
+
+## Project Overview
+
+This is a full-stack Retrieval-Augmented Generation (RAG) system designed to answer questions about course materials using semantic search and AI-powered responses. The application allows users to query course content and receive intelligent, context-aware answers.
+
+### Key Technologies
+
+- **Backend**: Python, FastAPI
+- **Frontend**: HTML, CSS, JavaScript
+- **AI**: Anthropic's Claude API
+- **Vector Database**: ChromaDB
+- **Embeddings**: Sentence Transformers
+- **Package Management**: uv
+
+### Architecture
+
+The system follows a client-server architecture:
+
+1. **Frontend**: A web interface that allows users to interact with the chatbot
+2. **Backend**: A FastAPI server that handles API requests and orchestrates the RAG pipeline
+3. **Vector Store**: ChromaDB for storing and retrieving course content embeddings
+4. **AI Generator**: Anthropic's Claude API for generating natural language responses
+5. **Document Processor**: Processes course documents into structured chunks for vector storage
+
+## Building and Running
+
+### Prerequisites
+
+- Python 3.13 or higher
+- uv (Python package manager)
+- An Anthropic API key
+
+### Setup
+
+1. **Install uv** (if not already installed):
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. **Install Python dependencies**:
+   ```bash
+   uv sync
+   ```
+
+3. **Set up environment variables**:
+   Create a `.env` file in the root directory with your Anthropic API key:
+   ```bash
+   ANTHROPIC_API_KEY=your_anthropic_api_key_here
+   ```
+
+### Running the Application
+
+#### Quick Start (Recommended)
+
+```bash
+chmod +x run.sh
+./run.sh
+```
+
+#### Manual Start
+
+```bash
+cd backend
+uv run uvicorn app:app --reload --port 8000
+```
+
+### Accessing the Application
+
+Once running, the application will be available at:
+- Web Interface: `http://localhost:8000`
+- API Documentation: `http://localhost:8000/docs`
+
+## Development Conventions
+
+### Code Structure
+
+- **backend/**: Contains all Python backend code
+  - `app.py`: Main FastAPI application
+  - `rag_system.py`: Core RAG system orchestrator
+  - `document_processor.py`: Handles document parsing and chunking
+  - `vector_store.py`: Manages ChromaDB interactions
+  - `ai_generator.py`: Interfaces with Anthropic's Claude API
+  - `search_tools.py`: Implements tool-based search functionality
+  - `session_manager.py`: Manages conversation history
+  - `config.py`: Application configuration
+  - `models.py`: Data models using Pydantic
+
+- **frontend/**: Contains all frontend code
+  - `index.html`: Main HTML file
+  - `script.js`: Client-side JavaScript logic
+  - `style.css`: Styling
+
+- **docs/**: Directory for course documents (loaded automatically on startup)
+
+### Adding Course Documents
+
+To add new course materials to the system:
+1. Place documents in the `docs/` directory
+2. Supported formats: `.pdf`, `.docx`, `.txt`
+3. Documents are automatically processed when the server starts
+4. Document format expected:
+   - Line 1: Course Title: [title]
+   - Line 2: Course Link: [url]
+   - Line 3: Course Instructor: [instructor]
+   - Following lines: Lesson markers and content (Lesson 1: Introduction, etc.)
+
+### API Endpoints
+
+- `POST /api/query`: Process a query about course materials
+- `GET /api/courses`: Get course statistics and titles
+
+### Development Workflow
+
+1. Make changes to the code
+2. The server automatically reloads with `--reload` flag
+3. Test changes through the web interface or API documentation
+4. Check the console for any error messages
+
+## Testing
+
+Currently, the project doesn't have explicit unit tests. Testing is done through:
+1. Manual testing via the web interface
+2. API testing through the auto-generated FastAPI docs at `http://localhost:8000/docs`

--- a/RAG_Chatbot_Architecture.md
+++ b/RAG_Chatbot_Architecture.md
@@ -1,0 +1,53 @@
+# RAG Chatbot System Architecture
+
+```mermaid
+flowchart TD
+    A[User] --> B[Frontend<br/>HTML/CSS/JavaScript]
+    B --> C[API Request<br/>/api/query]
+    C --> D[Backend<br/>FastAPI Server]
+    
+    subgraph Backend_System
+        D --> E[RAG System]
+        
+        E --> F[Document Processor]
+        E --> G[Vector Store<br/>ChromaDB]
+        E --> H[AI Generator<br/>Anthropic Claude]
+        E --> I[Session Manager]
+        E --> J[Tool Manager]
+        
+        J --> K[Search Tool]
+        K --> G
+        
+        F --> L[Parse Course Documents]
+        F --> M[Chunk Text Content]
+        
+        G --> N[Course Catalog<br/>Metadata Storage]
+        G --> O[Course Content<br/>Chunk Storage]
+        
+        H --> P[Send Query to Claude]
+        P --> Q{Tool Required?}
+        Q -->|Yes| R[Execute Search Tool]
+        R --> S[Semantic Search<br/>in Vector Store]
+        S --> T[Return Results]
+        T --> P
+        Q -->|No| U[Direct Response]
+        
+        U --> V[Update Session<br/>History]
+        T --> V
+    end
+    
+    V --> W[API Response<br/>Answer + Sources]
+    W --> B
+    B --> X[Display Results<br/>to User]
+    
+    subgraph Data_Flow
+        Y[Course Documents<br/>in /docs] --> Z[Load on Startup]
+        Z --> F
+        F --> G
+    end
+    
+    style A fill:#f9f,stroke:#333
+    style B fill:#bbf,stroke:#333
+    style D fill:#bfb,stroke:#333
+    style Y fill:#fbb,stroke:#333
+```

--- a/backend/ai_generator.py
+++ b/backend/ai_generator.py
@@ -29,8 +29,9 @@ All responses must be:
 Provide only the direct answer to what was asked.
 """
     
-    def __init__(self, api_key: str, model: str):
-        self.client = anthropic.Anthropic(api_key=api_key)
+    def __init__(self, api_key: str, model: str, base_url: str = "https://api.anthropic.com"):
+        # Pass the base_url to the Anthropic client
+        self.client = anthropic.Anthropic(api_key=api_key, base_url=base_url)
         self.model = model
         
         # Pre-build base API parameters

--- a/backend/config.py
+++ b/backend/config.py
@@ -10,7 +10,9 @@ class Config:
     """Configuration settings for the RAG system"""
     # Anthropic API settings
     ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
-    ANTHROPIC_MODEL: str = "claude-sonnet-4-20250514"
+    ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+    # Custom Anthropic API base URL (e.g., for Moonshot)
+    ANTHROPIC_BASE_URL: str = os.getenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com") # Default Anthropic URL
     
     # Embedding model settings
     EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"

--- a/backend/rag_system.py
+++ b/backend/rag_system.py
@@ -16,7 +16,7 @@ class RAGSystem:
         # Initialize core components
         self.document_processor = DocumentProcessor(config.CHUNK_SIZE, config.CHUNK_OVERLAP)
         self.vector_store = VectorStore(config.CHROMA_PATH, config.EMBEDDING_MODEL, config.MAX_RESULTS)
-        self.ai_generator = AIGenerator(config.ANTHROPIC_API_KEY, config.ANTHROPIC_MODEL)
+        self.ai_generator = AIGenerator(config.ANTHROPIC_API_KEY, config.ANTHROPIC_MODEL, config.ANTHROPIC_BASE_URL)
         self.session_manager = SessionManager(config.MAX_HISTORY)
         
         # Initialize search tools


### PR DESCRIPTION
主要变更

   1. 配置增强:
       * 在 Config 类中添加了 ANTHROPIC_BASE_URL
         配置项，允许从环境变量 .env 中读取自定义 URL，默认值为官方
         Anthropic API URL (https://api.anthropic.com)。
   2. AI 生成器适配:
       * 更新了 AIGenerator 类的构造函数，接受可选的 base_url
         参数，并将其传递给底层的 anthropic.Anthropic 客户端。
   3. 系统集成:
       * 修改了 RAGSystem 的初始化过程，确保在创建 AIGenerator
         实例时使用配置的 ANTHROPIC_BASE_URL。

  使用方法

  用户现在可以在 .env 文件中添加或修改以下行来配置自定义 API
  端点：

   1 ANTHROPIC_API_KEY=your_api_key_here
   2 ANTHROPIC_MODEL=claude-sonnet-4-20250514
   3 ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic/ #
     例如，使用 Moonshot AI 的 URL