### PR TITLE
Add course outline tool for retrieving course structure and lesson lists

### DIFF
--- a/backend/ai_generator.py
+++ b/backend/ai_generator.py
@@ -13,6 +13,10 @@ Search Tool Usage:
 - Synthesize search results into accurate, fact-based responses
 - If search yields no results, state this clearly without offering alternatives
 
+Course Outline Tool Usage:
+- Use the `get_course_outline` tool for questions about course structure, lesson lists, or outlines (e.g., "What lessons are in...", "Show me the outline of...", "What does the course cover?")
+- When presenting outline results, include the course title, course link, and each lesson's number and title
+
 Response Protocol:
 - **General knowledge questions**: Answer using existing knowledge without searching
 - **Course-specific questions**: Search first, then answer

--- a/backend/rag_system.py
+++ b/backend/rag_system.py
@@ -4,7 +4,7 @@ from document_processor import DocumentProcessor
 from vector_store import VectorStore
 from ai_generator import AIGenerator
 from session_manager import SessionManager
-from search_tools import ToolManager, CourseSearchTool
+from search_tools import ToolManager, CourseSearchTool, CourseOutlineTool
 from models import Course, Lesson, CourseChunk
 
 class RAGSystem:
@@ -23,7 +23,9 @@ class RAGSystem:
         self.tool_manager = ToolManager()
         self.search_tool = CourseSearchTool(self.vector_store)
         self.tool_manager.register_tool(self.search_tool)
-    
+        self.outline_tool = CourseOutlineTool(self.vector_store)
+        self.tool_manager.register_tool(self.outline_tool)
+
     def add_course_document(self, file_path: str) -> Tuple[Course, int]:
         """
         Add a single course document to the knowledge base.


### PR DESCRIPTION
Adds a CourseOutlineTool that handles queries about course outlines, lesson lists, and course structure by looking up course metadata and returning formatted title, link, instructor, and lesson details.