### PR TITLE
Replace Anthropic SDK with OpenRouter API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # Copy this file to .env and add your actual API key
-ANTHROPIC_API_KEY=your-anthropic-api-key-here
+OPENROUTER_API_KEY=sk-or-v1-<your-actual-key>

--- a/AddOpenRouter.md
+++ b/AddOpenRouter.md
@@ -1,0 +1,194 @@
+⏺ Now I have a complete picture. Here are the 5 files you need to update and exactly what to change in each:
+
+  ---
+  Step 1 — pyproject.toml
+
+  Replace the anthropic dependency with openai:
+
+  "openai>=1.0.0",
+
+  Remove: "anthropic==0.58.2",
+
+  Then run:
+  uv sync
+
+  ---
+  Step 2 — .env
+
+  Replace your key name:
+  OPENROUTER_API_KEY=sk-or-v1-...
+  
+  Remove the ANTHROPIC_API_KEY line.
+
+  ---
+  Step 3 — backend/config.py
+
+  Replace the Anthropic fields with OpenRouter fields:
+
+  OPENROUTER_API_KEY: str = os.getenv("OPENROUTER_API_KEY", "")
+  OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
+  OPENROUTER_MODEL: str = "anthropic/claude-sonnet-4-5"
+
+  Remove: ANTHROPIC_API_KEY and ANTHROPIC_MODEL.
+
+  ---
+  Step 4 — backend/search_tools.py
+  
+  OpenRouter uses the OpenAI tool format, not Anthropic's. In CourseSearchTool.get_tool_definition(), change the returned dict:
+
+  def get_tool_definition(self) -> Dict[str, Any]:
+      return {
+          "type": "function",
+          "function": {
+              "name": "search_course_content",
+              "description": "Search course materials with smart course name matching and lesson filtering",
+              "parameters": {
+                  "type": "object",
+                  "properties": {
+                      "query": {
+                          "type": "string",
+                          "description": "What to search for in the course content"
+                      },
+                      "course_name": {
+                          "type": "string",
+                          "description": "Course title (partial matches work, e.g. 'MCP', 'Introduction')"
+                      },
+                      "lesson_number": {
+                          "type": "integer",
+                          "description": "Specific lesson number to search within (e.g. 1, 2, 3)"
+                      }
+                  },
+                  "required": ["query"]
+              }
+          }
+      }
+
+  Key changes: wrap everything under "type": "function" + "function": {...}, and rename input_schema → parameters.
+
+  Also update ToolManager.execute_tool — it currently reads tool_name from tool_def.get("name") but now the name is nested. Fix register_tool:
+
+  def register_tool(self, tool: Tool):
+      tool_def = tool.get_tool_definition()
+      tool_name = tool_def["function"]["name"]   # was: tool_def.get("name")
+      self.tools[tool_name] = tool
+
+  ---
+  Step 5 — backend/ai_generator.py
+
+  This is the biggest change. The OpenAI SDK has a different response structure. Replace the entire file:
+
+  import json
+  from openai import OpenAI
+  from typing import List, Optional, Dict, Any
+
+  class AIGenerator:
+      SYSTEM_PROMPT = """ You are an AI assistant specialized in course materials..."""  # keep as-is
+
+      def __init__(self, api_key: str, base_url: str, model: str):
+          self.client = OpenAI(api_key=api_key, base_url=base_url)
+          self.model = model
+          self.base_params = {
+              "model": self.model,
+              "temperature": 0,
+              "max_tokens": 800
+          }
+
+      def generate_response(self, query, conversation_history=None, tools=None, tool_manager=None):
+          system_content = (
+              f"{self.SYSTEM_PROMPT}\n\nPrevious conversation:\n{conversation_history}"
+              if conversation_history
+              else self.SYSTEM_PROMPT
+          )
+
+          messages = [
+              {"role": "system", "content": system_content},
+              {"role": "user", "content": query}
+          ]
+
+          api_params = {**self.base_params, "messages": messages}
+          if tools:
+              api_params["tools"] = tools
+              api_params["tool_choice"] = "auto"
+
+          response = self.client.chat.completions.create(**api_params)
+          choice = response.choices[0]
+
+          if choice.finish_reason == "tool_calls" and tool_manager:
+              return self._handle_tool_execution(choice.message, messages, tool_manager)
+
+          return choice.message.content
+
+      def _handle_tool_execution(self, assistant_message, messages, tool_manager):
+          messages.append(assistant_message)  # add assistant's tool_calls message
+
+          for tool_call in assistant_message.tool_calls:
+              args = json.loads(tool_call.function.arguments)
+              result = tool_manager.execute_tool(tool_call.function.name, **args)
+              messages.append({
+                  "role": "tool",
+                  "tool_call_id": tool_call.id,
+                  "content": result
+              })
+
+          final_params = {**self.base_params, "messages": messages}
+          final_response = self.client.chat.completions.create(**final_params)
+          return final_response.choices[0].message.content
+
+  Key differences from the Anthropic version:
+  - system is now a message in the messages list, not a separate param
+  - response.choices[0].finish_reason == "tool_calls" replaces response.stop_reason == "tool_use"
+  - Tool args come as a JSON string (json.loads(tool_call.function.arguments)) not a dict
+  - Tool results are individual {"role": "tool", ...} messages, not a batched tool_result block
+
+  ---
+  Step 6 — backend/rag_system.py
+  
+  Update the AIGenerator constructor call (line 19) to pass the new params:
+
+              api_params["tools"] = tools
+              api_params["tool_choice"] = "auto"
+
+          response = self.client.chat.completions.create(**api_params)
+          choice = response.choices[0]
+
+          if choice.finish_reason == "tool_calls" and tool_manager:
+              return self._handle_tool_execution(choice.message, messages, tool_manager)
+
+          return choice.message.content
+
+      def _handle_tool_execution(self, assistant_message, messages, tool_manager):
+          messages.append(assistant_message)  # add assistant's tool_calls message
+
+          for tool_call in assistant_message.tool_calls:
+              args = json.loads(tool_call.function.arguments)
+              result = tool_manager.execute_tool(tool_call.function.name, **args)
+              messages.append({
+                  "role": "tool",
+                  "tool_call_id": tool_call.id,
+                  "content": result
+              })
+
+          final_params = {**self.base_params, "messages": messages}
+          final_response = self.client.chat.completions.create(**final_params)
+          return final_response.choices[0].message.content
+
+  Key differences from the Anthropic version:
+  - system is now a message in the messages list, not a separate param
+  - response.choices[0].finish_reason == "tool_calls" replaces response.stop_reason == "tool_use"
+  - Tool args come as a JSON string (json.loads(tool_call.function.arguments)) not a dict
+  - Tool results are individual {"role": "tool", ...} messages, not a batched tool_result block
+
+  ---
+  Step 6 — backend/rag_system.py
+
+  Update the AIGenerator constructor call (line 19) to pass the new params:
+
+  self.ai_generator = AIGenerator(
+      config.OPENROUTER_API_KEY,
+      config.OPENROUTER_BASE_URL,
+      config.OPENROUTER_MODEL
+  )
+
+  ---
+  That covers all the changes. The model string anthropic/claude-sonnet-4-5 is OpenRouter's ID for Claude Sonnet — you can browse openrouter.ai/models to pick a different one
+  if needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+uv sync
+
+# Run the app (from repo root)
+./run.sh
+# or manually:
+cd backend && uv run uvicorn app:app --reload --port 8000
+```
+
+The server starts at `http://localhost:8000`. API docs at `http://localhost:8000/docs`.
+
+Requires a `.env` file at the repo root with `ANTHROPIC_API_KEY=...` (see `.env.example`).
+
+There are no tests in this codebase.
+
+## Architecture
+
+This is a full-stack RAG chatbot. The **backend** is a FastAPI app in `backend/`; the **frontend** is plain HTML/CSS/JS in `frontend/`, served as static files by FastAPI. Course documents live in `docs/` as `.txt` files.
+
+### Query pipeline
+
+Every user message flows through this chain:
+
+```
+app.py → RAGSystem → AIGenerator → Claude API (1st call, tool_use)
+                                 → VectorStore → ChromaDB
+                                 → Claude API (2nd call, final answer)
+```
+
+1. `app.py` receives `POST /api/query`, creates a session if needed, delegates to `RAGSystem.query()`.
+2. `RAGSystem` fetches conversation history from `SessionManager`, then calls `AIGenerator.generate_response()` with the `search_course_content` tool definition.
+3. **First Claude call**: Claude receives the system prompt, conversation history, and the tool. It either answers directly (general knowledge) or returns `stop_reason: "tool_use"`.
+4. If tool use: `ToolManager` dispatches to `CourseSearchTool`, which calls `VectorStore.search()`. The store first resolves a fuzzy course name via semantic search on the `course_catalog` ChromaDB collection, then retrieves top-5 content chunks from `course_content` with optional course/lesson filters.
+5. **Second Claude call**: tool results are appended to the message history; Claude synthesizes the final answer.
+6. The exchange is saved to `SessionManager` (keeps last 2 exchanges). Sources are extracted from `CourseSearchTool.last_sources` and returned alongside the answer.
+
+### Key design points
+
+- **Two ChromaDB collections**: `course_catalog` holds one document per course (title, instructor, lesson links); `course_content` holds chunked lesson text. Both use `all-MiniLM-L6-v2` embeddings.
+- **Course name resolution**: fuzzy/partial course names work because course lookup uses vector similarity against `course_catalog` before filtering `course_content`.
+- **Tool as the only retrieval path**: there is no direct vector search fallback — all course retrieval goes through Claude's tool call decision. If Claude doesn't call the tool, no RAG retrieval happens.
+- **Session history is a formatted string**, not a message array. It's injected into the system prompt, not the messages list.
+- **Document format**: course `.txt` files must follow a strict header format (`Course Title:`, `Course Link:`, `Course Instructor:`) followed by `Lesson N: <title>` / `Lesson Link:` blocks. The `DocumentProcessor` parses this format; deviations fall back to treating the whole file as one unchunked document.
+- **Chunk IDs** in ChromaDB are `{course_title_underscored}_{chunk_index}`. Re-ingesting the same course title is a no-op (titles are checked against existing IDs before processing).

--- a/backend/ai_generator.py
+++ b/backend/ai_generator.py
@@ -1,9 +1,8 @@
-import anthropic
+import json
+from openai import OpenAI
 from typing import List, Optional, Dict, Any
 
 class AIGenerator:
-    """Handles interactions with Anthropic's Claude API for generating responses"""
-    
     # Static system prompt to avoid rebuilding on each call
     SYSTEM_PROMPT = """ You are an AI assistant specialized in course materials and educational content with access to a comprehensive search tool for course information.
 
@@ -29,107 +28,52 @@ All responses must be:
 Provide only the direct answer to what was asked.
 """
     
-    def __init__(self, api_key: str, model: str):
-        self.client = anthropic.Anthropic(api_key=api_key)
+    def __init__(self, api_key: str, base_url: str, model: str):
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.model = model
-        
-        # Pre-build base API parameters
         self.base_params = {
             "model": self.model,
             "temperature": 0,
             "max_tokens": 800
         }
-    
-    def generate_response(self, query: str,
-                         conversation_history: Optional[str] = None,
-                         tools: Optional[List] = None,
-                         tool_manager=None) -> str:
-        """
-        Generate AI response with optional tool usage and conversation context.
-        
-        Args:
-            query: The user's question or request
-            conversation_history: Previous messages for context
-            tools: Available tools the AI can use
-            tool_manager: Manager to execute tools
-            
-        Returns:
-            Generated response as string
-        """
-        
-        # Build system content efficiently - avoid string ops when possible
+
+    def generate_response(self, query, conversation_history=None, tools=None, tool_manager=None):
         system_content = (
             f"{self.SYSTEM_PROMPT}\n\nPrevious conversation:\n{conversation_history}"
-            if conversation_history 
+            if conversation_history
             else self.SYSTEM_PROMPT
         )
-        
-        # Prepare API call parameters efficiently
-        api_params = {
-            **self.base_params,
-            "messages": [{"role": "user", "content": query}],
-            "system": system_content
-        }
-        
-        # Add tools if available
+
+        messages = [
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": query}
+        ]
+
+        api_params = {**self.base_params, "messages": messages}
         if tools:
             api_params["tools"] = tools
-            api_params["tool_choice"] = {"type": "auto"}
-        
-        # Get response from Claude
-        response = self.client.messages.create(**api_params)
-        
-        # Handle tool execution if needed
-        if response.stop_reason == "tool_use" and tool_manager:
-            return self._handle_tool_execution(response, api_params, tool_manager)
-        
-        # Return direct response
-        return response.content[0].text
-    
-    def _handle_tool_execution(self, initial_response, base_params: Dict[str, Any], tool_manager):
-        """
-        Handle execution of tool calls and get follow-up response.
-        
-        Args:
-            initial_response: The response containing tool use requests
-            base_params: Base API parameters
-            tool_manager: Manager to execute tools
-            
-        Returns:
-            Final response text after tool execution
-        """
-        # Start with existing messages
-        messages = base_params["messages"].copy()
-        
-        # Add AI's tool use response
-        messages.append({"role": "assistant", "content": initial_response.content})
-        
-        # Execute all tool calls and collect results
-        tool_results = []
-        for content_block in initial_response.content:
-            if content_block.type == "tool_use":
-                tool_result = tool_manager.execute_tool(
-                    content_block.name, 
-                    **content_block.input
-                )
-                
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": content_block.id,
-                    "content": tool_result
-                })
-        
-        # Add tool results as single message
-        if tool_results:
-            messages.append({"role": "user", "content": tool_results})
-        
-        # Prepare final API call without tools
-        final_params = {
-            **self.base_params,
-            "messages": messages,
-            "system": base_params["system"]
-        }
-        
-        # Get final response
-        final_response = self.client.messages.create(**final_params)
-        return final_response.content[0].text
+            api_params["tool_choice"] = "auto"
+
+        response = self.client.chat.completions.create(**api_params)
+        choice = response.choices[0]
+
+        if choice.finish_reason == "tool_calls" and tool_manager:
+            return self._handle_tool_execution(choice.message, messages, tool_manager)
+
+        return choice.message.content
+
+    def _handle_tool_execution(self, assistant_message, messages, tool_manager):
+        messages.append(assistant_message)  # add assistant's tool_calls message
+
+        for tool_call in assistant_message.tool_calls:
+            args = json.loads(tool_call.function.arguments)
+            result = tool_manager.execute_tool(tool_call.function.name, **args)
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool_call.id,
+                "content": result
+            })
+
+        final_params = {**self.base_params, "messages": messages}
+        final_response = self.client.chat.completions.create(**final_params)
+        return final_response.choices[0].message.content

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,8 +9,11 @@ load_dotenv()
 class Config:
     """Configuration settings for the RAG system"""
     # Anthropic API settings
-    ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
-    ANTHROPIC_MODEL: str = "claude-sonnet-4-20250514"
+    # ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
+    # ANTHROPIC_MODEL: str = "claude-sonnet-4-20250514"
+    OPENROUTER_API_KEY: str = os.getenv("OPENROUTER_API_KEY", "")
+    OPENROUTER_BASE_URL: str = "https://openrouter.ai/api/v1"
+    OPENROUTER_MODEL: str = "anthropic/claude-sonnet-4-5"
     
     # Embedding model settings
     EMBEDDING_MODEL: str = "all-MiniLM-L6-v2"

--- a/backend/rag_system.py
+++ b/backend/rag_system.py
@@ -16,7 +16,8 @@ class RAGSystem:
         # Initialize core components
         self.document_processor = DocumentProcessor(config.CHUNK_SIZE, config.CHUNK_OVERLAP)
         self.vector_store = VectorStore(config.CHROMA_PATH, config.EMBEDDING_MODEL, config.MAX_RESULTS)
-        self.ai_generator = AIGenerator(config.ANTHROPIC_API_KEY, config.ANTHROPIC_MODEL)
+        # self.ai_generator = AIGenerator(config.ANTHROPIC_API_KEY, config.ANTHROPIC_MODEL)
+        self.ai_generator = AIGenerator(config.OPENROUTER_API_KEY, config.OPENROUTER_BASE_URL, config.OPENROUTER_MODEL)
         self.session_manager = SessionManager(config.MAX_HISTORY)
         
         # Initialize search tools

--- a/backend/search_tools.py
+++ b/backend/search_tools.py
@@ -25,29 +25,31 @@ class CourseSearchTool(Tool):
         self.last_sources = []  # Track sources from last search
     
     def get_tool_definition(self) -> Dict[str, Any]:
-        """Return Anthropic tool definition for this tool"""
-        return {
-            "name": "search_course_content",
-            "description": "Search course materials with smart course name matching and lesson filtering",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string", 
-                        "description": "What to search for in the course content"
-                    },
-                    "course_name": {
-                        "type": "string",
-                        "description": "Course title (partial matches work, e.g. 'MCP', 'Introduction')"
-                    },
-                    "lesson_number": {
-                        "type": "integer",
-                        "description": "Specific lesson number to search within (e.g. 1, 2, 3)"
-                    }
-                },
-                "required": ["query"]
-            }
-        }
+      return {
+          "type": "function",
+          "function": {
+              "name": "search_course_content",
+              "description": "Search course materials with smart course name matching and lesson filtering",
+              "parameters": {
+                  "type": "object",
+                  "properties": {
+                      "query": {
+                          "type": "string",
+                          "description": "What to search for in the course content"
+                      },
+                      "course_name": {
+                          "type": "string",
+                          "description": "Course title (partial matches work, e.g. 'MCP', 'Introduction')"
+                      },
+                      "lesson_number": {
+                          "type": "integer",
+                          "description": "Specific lesson number to search within (e.g. 1, 2, 3)"
+                      }
+                  },
+                  "required": ["query"]
+              }
+          }
+      }
     
     def execute(self, query: str, course_name: Optional[str] = None, lesson_number: Optional[int] = None) -> str:
         """
@@ -120,12 +122,9 @@ class ToolManager:
         self.tools = {}
     
     def register_tool(self, tool: Tool):
-        """Register any tool that implements the Tool interface"""
-        tool_def = tool.get_tool_definition()
-        tool_name = tool_def.get("name")
-        if not tool_name:
-            raise ValueError("Tool must have a 'name' in its definition")
-        self.tools[tool_name] = tool
+      tool_def = tool.get_tool_definition()
+      tool_name = tool_def["function"]["name"]   # was: tool_def.get("name")
+      self.tools[tool_name] = tool
 
     
     def get_tool_definitions(self) -> list:

--- a/docs/query_flow.html
+++ b/docs/query_flow.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>RAG Chatbot — Query Flow</title>
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #f8f9fa;
+      margin: 0;
+      padding: 2rem;
+    }
+    h1 {
+      font-size: 1.4rem;
+      color: #1a1a2e;
+      margin-bottom: 0.25rem;
+    }
+    p.subtitle {
+      color: #555;
+      font-size: 0.9rem;
+      margin-top: 0;
+      margin-bottom: 2rem;
+    }
+    .diagram-wrapper {
+      background: #fff;
+      border-radius: 10px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+      padding: 2rem;
+      max-width: 900px;
+      margin: 0 auto;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <div class="diagram-wrapper">
+    <h1>RAG Chatbot — Query Flow</h1>
+    <p class="subtitle">End-to-end trace of a user query from the browser through the backend and back.</p>
+    <div class="mermaid">
+sequenceDiagram
+    actor User
+    participant FE as Frontend<br/>(script.js)
+    participant API as FastAPI<br/>(app.py)
+    participant RAG as RAGSystem<br/>(rag_system.py)
+    participant SM as SessionManager<br/>(session_manager.py)
+    participant AI as AIGenerator<br/>(ai_generator.py)
+    participant Claude as Claude API<br/>(Anthropic)
+    participant TM as ToolManager<br/>(search_tools.py)
+    participant VS as VectorStore<br/>(vector_store.py)
+    participant DB as ChromaDB
+
+    User->>FE: Types message, presses Enter
+    FE->>FE: Disable input, show loading bubble
+    FE->>API: POST /api/query<br/>{ query, session_id }
+
+    API->>SM: create_session() if no session_id
+    SM-->>API: session_id (e.g. "session_1")
+
+    API->>RAG: query(query, session_id)
+
+    RAG->>SM: get_conversation_history(session_id)
+    SM-->>RAG: formatted prior exchanges (or null)
+
+    RAG->>AI: generate_response(prompt, history, tools)
+
+    Note over AI,Claude: 1st API Call — Claude decides whether to search
+    AI->>Claude: messages + system prompt +<br/>search_course_content tool definition
+    Claude-->>AI: stop_reason: "tool_use"<br/>{ name, query, course_name?, lesson_number? }
+
+    AI->>TM: execute_tool("search_course_content", ...)
+    TM->>VS: search(query, course_name, lesson_number)
+
+    alt course_name provided
+        VS->>DB: query course_catalog<br/>(vector similarity on course name)
+        DB-->>VS: best-matching course title
+    end
+
+    VS->>DB: query course_content<br/>(vector similarity, filtered by course/lesson)
+    DB-->>VS: top-5 matching chunks + metadata
+
+    VS-->>TM: SearchResults (documents, metadata)
+    TM-->>AI: formatted string:<br/>"[Course - Lesson N]\n<chunk text>"
+
+    Note over AI,Claude: 2nd API Call — Claude synthesizes the answer
+    AI->>Claude: original messages +<br/>tool_result block (search results)
+    Claude-->>AI: final answer text
+
+    AI-->>RAG: answer string
+
+    RAG->>SM: add_exchange(session_id, query, answer)
+    RAG->>TM: get_last_sources() → reset_sources()
+    RAG-->>API: (answer, sources)
+
+    API-->>FE: { answer, sources, session_id }
+
+    FE->>FE: Remove loading bubble
+    FE->>FE: Render answer via marked.parse()<br/>Render sources in collapsible &lt;details&gt;
+    FE->>User: Displays formatted response
+    </div>
+  </div>
+
+  <script>
+    mermaid.initialize({ startOnLoad: true, theme: 'default', sequence: { actorMargin: 60, messageMargin: 30 } });
+  </script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "chromadb==1.0.15",
-    "anthropic==0.58.2",
+    "openai>=1.0.0",
     "sentence-transformers==5.0.0",
     "fastapi==0.116.1",
     "uvicorn==0.35.0",

--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ if [ ! -d "backend" ]; then
 fi
 
 echo "Starting Course Materials RAG System..."
-echo "Make sure you have set your ANTHROPIC_API_KEY in .env"
+echo "Make sure you have set your OPENROUTER_API_KEY in .env"
 
 # Change to backend directory and start the server
 cd backend && uv run uvicorn app:app --reload --port 8000

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -9,24 +9,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anthropic"
-version = "0.58.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/b9/ab06c586aa5a5e7499017cee5ebab94ee260e75975c45395f32b8592abdd/anthropic-0.58.2.tar.gz", hash = "sha256:86396cc45530a83acea25ae6bca9f86656af81e3d598b4d22a1300e0e4cf8df8", size = 425125, upload-time = "2025-07-18T13:38:55.94Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/f2/68d908ff308c9a65af5749ec31952e01d32f19ea073b0268affc616e6ebc/anthropic-0.58.2-py3-none-any.whl", hash = "sha256:3742181c634c725f337b71096839b6404145e33a8e190c75387c4028b825864d", size = 292896, upload-time = "2025-07-18T13:38:54.782Z" },
 ]
 
 [[package]]
@@ -861,6 +843,25 @@ wheels = [
 ]
 
 [[package]]
+name = "openai"
+version = "2.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1552,9 +1553,9 @@ name = "starting-codebase"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "anthropic" },
     { name = "chromadb" },
     { name = "fastapi" },
+    { name = "openai" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "sentence-transformers" },
@@ -1563,9 +1564,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = "==0.58.2" },
     { name = "chromadb", specifier = "==1.0.15" },
     { name = "fastapi", specifier = "==0.116.1" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "python-multipart", specifier = "==0.0.20" },
     { name = "sentence-transformers", specifier = "==5.0.0" },


### PR DESCRIPTION
**Description:**

Swaps the AI provider from Anthropic's SDK to OpenRouter, enabling access to multiple model providers through a single API key.

**Changes:**
 - Replaced anthropic package with openai in pyproject.toml (OpenRouter uses the OpenAI-compatible API)
 - Updated config.py to read OPENROUTER_API_KEY and OPENROUTER_BASE_URL from environment
 - Rewrote ai_generator.py to use the OpenAI client pointed at https://openrouter.ai/api/v1
 - Updated tool definition format in search_tools.py from Anthropic's input_schema format to OpenAI's parameters format
 - Updated rag_system.py and run.sh to reference the new config fields

**Testing:**
  Verified end-to-end: course queries return correct answers and sources via the OpenRouter-hosted Claude model (anthropic/claude-sonnet-4-5).